### PR TITLE
Unify the call of :methods in to_xml

### DIFF
--- a/lib/dm-serializer/to_xml.rb
+++ b/lib/dm-serializer/to_xml.rb
@@ -29,7 +29,7 @@ module DataMapper
         xml.add_node(root, property.name.to_s, value, attrs)
       end
 
-      (opts[:methods] || []).each do |meth|
+      Array(opts[:methods]).each do |meth|
         if self.respond_to?(meth)
           xml_name = meth.to_s.gsub(/[^a-z0-9_]/, '')
           value = __send__(meth)


### PR DESCRIPTION
Currently this works:
# to_json(:methods => :collection_method)

Currently this does not work with #to_xml; instead the following is required:
# to_xml(:methods => [:collection_method])

This patch unifies the calling arguments, now #to_xml works without extra [ ].

Btw, the test enviroment for rspec seems to be a little bit messed up: 
   % rake spec
    "Don't know how to build task 'check_dependencies'"

I couldn't get the test environment running and there was no existing test for this problem.
