### PR TITLE
Prevent libxml-ruby from being bundled on Rubinius, as it is broken.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,12 +25,17 @@ end
 group :development do # Development dependencies (as in the gemspec)
 
   gem 'dm-validations', DM_VERSION, SOURCE => "#{DATAMAPPER}/dm-validations#{REPO_POSTFIX}"
-  gem 'nokogiri',       '~> 1.4.1'
-  gem 'libxml-ruby',    '~> 1.1.4', :platforms => [ :ruby, :mswin ]
 
   gem 'rake',           '~> 0.8.7'
   gem 'rspec',          '~> 1.3.1'
   gem 'jeweler',        '~> 1.5.2'
+
+end
+
+group :testing do # Testing dependencies
+
+  gem 'nokogiri',       '~> 1.4.1'
+  gem 'libxml-ruby',    '~> 1.1.4', :platforms => [ :mri, :mswin ]
 
 end
 

--- a/dm-serializer.gemspec
+++ b/dm-serializer.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Guy van den Berg"]
-  s.date = %q{2011-02-19}
+  s.date = %q{2011-02-23}
   s.description = %q{DataMapper plugin for serializing Resources and Collections}
   s.email = %q{vandenberg.guy [a] gmail [d] com}
   s.extra_rdoc_files = [
@@ -83,8 +83,6 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<fastercsv>, ["~> 1.5.3"])
       s.add_runtime_dependency(%q<json>, ["~> 1.5.1"])
       s.add_development_dependency(%q<dm-validations>, ["~> 1.0.2"])
-      s.add_development_dependency(%q<nokogiri>, ["~> 1.4.1"])
-      s.add_development_dependency(%q<libxml-ruby>, ["~> 1.1.4"])
       s.add_development_dependency(%q<rake>, ["~> 0.8.7"])
       s.add_development_dependency(%q<rspec>, ["~> 1.3.1"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.2"])
@@ -95,8 +93,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<fastercsv>, ["~> 1.5.3"])
       s.add_dependency(%q<json>, ["~> 1.5.1"])
       s.add_dependency(%q<dm-validations>, ["~> 1.0.2"])
-      s.add_dependency(%q<nokogiri>, ["~> 1.4.1"])
-      s.add_dependency(%q<libxml-ruby>, ["~> 1.1.4"])
       s.add_dependency(%q<rake>, ["~> 0.8.7"])
       s.add_dependency(%q<rspec>, ["~> 1.3.1"])
       s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
@@ -108,8 +104,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<fastercsv>, ["~> 1.5.3"])
     s.add_dependency(%q<json>, ["~> 1.5.1"])
     s.add_dependency(%q<dm-validations>, ["~> 1.0.2"])
-    s.add_dependency(%q<nokogiri>, ["~> 1.4.1"])
-    s.add_dependency(%q<libxml-ruby>, ["~> 1.1.4"])
     s.add_dependency(%q<rake>, ["~> 0.8.7"])
     s.add_dependency(%q<rspec>, ["~> 1.3.1"])
     s.add_dependency(%q<jeweler>, ["~> 1.5.2"])


### PR DESCRIPTION
Do not bundle libxml-ruby on platforms besides MRI and MSWin. This will prevent libxml-ruby needing to be installed on Rubinius, since libxml-ruby is known to not build on Rubinius (http://rubyforge.org/tracker/?func=detail&aid=28967&group_id=494&atid=1971). This should fix the CI failures that dm-serializer has on rbx.
