### PR TITLE
Use multi_json on the Collection as well as on the resources.

### DIFF
--- a/lib/dm-serializer/to_json.rb
+++ b/lib/dm-serializer/to_json.rb
@@ -86,7 +86,7 @@ module DataMapper
 
       # default to making JSON
       if options.fetch(:to_json, true)
-        collection.to_json
+        MultiJson.encode(collection)
       else
         collection
       end


### PR DESCRIPTION
This fixes an exception when calling `#to_json` on a Collection, unless you happen to be in a project that has added `to_json` to Array (e.g. Rails, or a project depending on the 'json' gem).

No spec changes since they weren't failing before or after (not sure why?).  There is a gist here showing quite clearly the bug though:

https://gist.github.com/1304016
