### PR TITLE
Remove double new line

### DIFF
--- a/lib/dm-serializer/to_csv.rb
+++ b/lib/dm-serializer/to_csv.rb
@@ -55,7 +55,7 @@ module DataMapper
     def to_csv(*args)
       result = ''
       each do |item|
-        result << item.to_csv(args.first) + "\n"
+        result << item.to_csv(args.first)
       end
       result
     end


### PR DESCRIPTION
Currently the serializer created a double linefeed. this causes problems when importing p.ex. into excel
